### PR TITLE
Rev api gateway version for release

### DIFF
--- a/api-gateway/cloud/terraform/modules/eks-client/variables.tf
+++ b/api-gateway/cloud/terraform/modules/eks-client/variables.tf
@@ -41,11 +41,11 @@ variable "consul_version" {
 variable "chart_version" {
   type        = string
   description = "The Consul Helm chart version to use"
-  default     = "0.47.1"
+  default     = "1.0.0"
 }
 
 variable "api_gateway_version" {
   type        = string
   description = "The Consul API gateway image version to use"
-  default     = "0.4.0"
+  default     = "0.5.0"
 }

--- a/api-gateway/cloud/terraform/variables.tf
+++ b/api-gateway/cloud/terraform/variables.tf
@@ -37,11 +37,11 @@ variable "consul_tier" {
 variable "consul_version" {
   type        = string
   description = "The HCP Consul version"
-  default     = "v1.13.1"
+  default     = "v1.14.0"
 }
 
 variable "api_gateway_version" {
   type        = string
   description = "The Consul API gateway CRD version to use"
-  default     = "0.4.0"
+  default     = "0.5.0"
 }

--- a/api-gateway/local/consul/config.yaml
+++ b/api-gateway/local/consul/config.yaml
@@ -15,7 +15,7 @@ controller:
   enabled: true
 apiGateway:
   enabled: true
-  image: "hashicorp/consul-api-gateway:0.4.0"
+  image: "hashicorp/consul-api-gateway:0.5.0"
   managedGatewayClass:
     serviceType: NodePort
     useHostPorts: true


### PR DESCRIPTION
This updates the helm manifests to use the latest API gateway version coinciding with our 0.5.0 release.