### PR TITLE
API GW: updating echo image

### DIFF
--- a/api-gateway/cloud/two-services/echo-1.yaml
+++ b/api-gateway/cloud/two-services/echo-1.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       serviceAccountName: echo-1
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+      - image: kicbase/echo-server:1.0
         name: echo-1
         ports:
         - containerPort: 8080

--- a/api-gateway/cloud/two-services/echo-2.yaml
+++ b/api-gateway/cloud/two-services/echo-2.yaml
@@ -20,7 +20,7 @@ spec:
   - port: 8090
     name: high
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8090
   selector:
     app: echo-2
 ---
@@ -50,7 +50,7 @@ spec:
     spec:
       serviceAccountName: echo-2
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+      - image: kicbase/echo-server:1.0
         name: echo-2
         ports:
-        - containerPort: 8080
+        - containerPort: 8090

--- a/api-gateway/local/two-services/echo-1.yaml
+++ b/api-gateway/local/two-services/echo-1.yaml
@@ -22,7 +22,7 @@ spec:
   - port: 8080
     name: high
     protocol: TCP
-    targetPort: 3000
+    targetPort: 8080
   selector:
     app: echo-1
 ---
@@ -54,7 +54,7 @@ spec:
     spec:
       serviceAccountName: echo-1
       containers:
-      - image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
+      - image: kicbase/echo-server:1.0
         name: echo-1
         env:
         - name: SERVICE_NAME
@@ -68,4 +68,4 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         ports:
-        - containerPort: 3000
+        - containerPort: 8080

--- a/api-gateway/local/two-services/echo-2.yaml
+++ b/api-gateway/local/two-services/echo-2.yaml
@@ -22,7 +22,7 @@ spec:
   - port: 8090
     name: high
     protocol: TCP
-    targetPort: 3000
+    targetPort: 8090
   selector:
     app: echo-2
 ---
@@ -54,7 +54,7 @@ spec:
     spec:
       serviceAccountName: echo-2
       containers:
-      - image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
+      - image: kicbase/echo-server:1.0
         name: echo-2
         env:
         - name: SERVICE_NAME
@@ -68,4 +68,4 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         ports:
-        - containerPort: 3000
+        - containerPort: 8090


### PR DESCRIPTION
With `k8s.gcr.io` being deprecated, switching over to another echo image.